### PR TITLE
feat(git-wt-branch): add fzf_git_wt_branch for worktree from existing branch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,32 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+A [Fisher](https://github.com/jorgebucaran/fisher)-installable fish-shell plugin providing fzf wrappers for common interactive selections. Each function is a standalone `.fish` file under `functions/`, which Fisher autoloads by filename (`functions/fzf_ghq.fish` defines `fzf_ghq`). `functions/*.fish` is the source of truth for what features exist. There is no build, test, or lint tooling.
+
+## Development
+
+- **Run/test a function locally**: source it, then invoke it interactively. `source functions/fzf_ghq.fish; fzf_ghq`
+- **Adding a function**: create `functions/<name>.fish` defining a function of the same name, then document it in `README.md` if relevant.
+- Functions assume their external CLI dependency (`fzf`, plus per-function tools like `ghq`, `gh`, `git-wt`, `fd`, `rg`, `kubectl`, `gcloud`, `z`) is installed. These are not bundled or checked.
+
+## Conventions
+
+Every function follows the same shape — match it when editing or adding:
+
+1. `set -l fzf_flags $argv` first, so callers can pass extra fzf flags (the README's `wrap_*` examples rely on this).
+2. Produce candidate lines → pipe to `fzf $fzf_flags` → `read line` (or capture into a var).
+3. Guard with `if test $line` / `if test -n "$selected"` before acting — never act on an empty selection.
+4. Terminal action by intent:
+   - **Directory change** (cd-style: `fzf_cd`, `fzf_ghq`, `fzf_z`, `fzf_git_wt`): `cd $line; commandline -f repaint`.
+   - **Edit the command line for the user to run** (`fzf_history`, `fzf_k8s_context`): `commandline "<cmd>"` — and `commandline ''` on cancel to clear.
+   - **Execute immediately** (`fzf_file`): `commandline "$EDITOR $line"; commandline -f execute`.
+5. When parsing tabular CLI output, select the column with `awk '{print $1}'` (or the relevant index) rather than fragile string slicing.
+
+When a function needs a user-provided value, read it from an environment variable with a sensible fallback inside the function rather than hardcoding (e.g. `FZF_CD_MAX_DEPTH`, `FZF_GH_PR_CHECKOUT_REVIEWER` defaulting to `git config user.name`). Grep the function for the actual variable names.
+
+## Notable detail
+
+`fzf_gh_pr_wt` fetches the PR ref into `FETCH_HEAD` (`git fetch <remote> pull/<n>/head`) before creating a worktree, deliberately avoiding any update to checked-out branches. The remote is resolved from the `gh-resolved` git config (set by `gh`), falling back to `origin`. Preserve this fetch-to-FETCH_HEAD behavior if modifying worktree/PR logic.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Use fzf with:
 * [ghq](https://github.com/motemen/ghq)
 * git switch branch based on [GitHub pull request](https://cli.github.com/manual/gh_pr_list)
 * [git-wt](https://github.com/k1LoW/git-wt) switching
+* [git-wt](https://github.com/k1LoW/git-wt) worktree from an existing branch (local or remote)
 * [git-wt](https://github.com/k1LoW/git-wt) checkout from [GitHub pull request](https://cli.github.com/manual/gh_pr_list)
 * history
 * [z](https://github.com/fisherman/z)

--- a/functions/fzf_git_wt_branch.fish
+++ b/functions/fzf_git_wt_branch.fish
@@ -1,0 +1,30 @@
+function fzf_git_wt_branch
+  set -l fzf_flags $argv
+
+  set -l locals (git for-each-ref --format='%(refname:short)' refs/heads)
+
+  # remote-tracking branches without a local counterpart, so origin/feat/x and
+  # feat/x are not both offered for the same worktree
+  set -l remotes
+  for r in (git for-each-ref --format='%(refname:short)' refs/remotes)
+    # real remote-tracking branches are <remote>/<branch>; the bare <remote>
+    # entry is the HEAD symref (e.g. origin -> origin/master), skip it
+    string match -q '*/*' $r; or continue
+    set -l short (string replace -r '^[^/]+/' '' $r)
+    contains -- $short $locals; and continue
+    set -a remotes $r
+  end
+
+  printf '%s\n' $locals $remotes | fzf $fzf_flags | read selected
+  if test -z "$selected"
+    return 0
+  end
+
+  if contains -- $selected $remotes
+    # remote-only branch: create a local branch from the remote-tracking ref
+    git wt (string replace -r '^[^/]+/' '' $selected) $selected
+  else
+    git wt $selected
+  end
+  commandline -f repaint
+end


### PR DESCRIPTION
## Summary

- Add `fzf_git_wt_branch`: fzf-select a local or remote branch and create a worktree from it via `git wt`.
- Document the new feature in README and add a CLAUDE.md repository guide.

## Notes

- Remote-tracking refs are deduped against their local counterparts, so a branch with both `origin/feat/x` and `feat/x` is offered only once (as the local). A remote-only selection creates a local branch from the remote ref.